### PR TITLE
Add cursor: pointer to all buttons

### DIFF
--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -8,6 +8,7 @@
   text-decoration: none;
   display: inline-block;
   background-color: var(--accentColor);
+  cursor: pointer;
 }
 
 .btn:active,
@@ -19,6 +20,7 @@
 
 .btn:disabled {
   background-color: var(--disabled);
+  cursor: not-allowed;
 }
 
 .btn:hover {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -40,7 +40,7 @@
     to-fast-properties "^2.0.0"
 
 "@dracula/dracula-ui@file:../dist":
-  version "0.6.0"
+  version "0.6.1"
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.20"


### PR DESCRIPTION
This change makes it so that every button ships with `cursor: pointer`,
and sets the cursor to `not-allowed` for disabled buttons.

More context here: https://github.com/dracula/dracula-ui/issues/29