### PR TITLE
Fix multi-line linear gradients on Safari

### DIFF
--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -103,6 +103,7 @@
     -moz-background-clip: text;
     -webkit-text-fill-color: transparent;
     -moz-text-fill-color: transparent;
+    -webkit-box-decoration-break: clone;
   }
 }
 


### PR DESCRIPTION
Before

<img width="310" alt="Screen Shot 2021-04-16 at 8 11 33 AM" src="https://user-images.githubusercontent.com/398893/115045501-69f15b00-9e8b-11eb-8e06-365554975ae6.png">

After

<img width="307" alt="Screen Shot 2021-04-16 at 8 11 44 AM" src="https://user-images.githubusercontent.com/398893/115045512-6d84e200-9e8b-11eb-8577-bd5bd3fd77dd.png">
