### PR TITLE
Add support for new input types

### DIFF
--- a/dsp/data/components.json
+++ b/dsp/data/components.json
@@ -5715,17 +5715,24 @@
         },
         {
           "title": "Sizes",
-          "html": "<div class=\"drac-box\">\n  <input placeholder=\"small\" class=\"drac-input drac-input-sm drac-m-xs\" /><input\n    placeholder=\"medium\"\n    class=\"drac-input drac-m-xs\"\n  /><input placeholder=\"large\" class=\"drac-input drac-input-lg drac-m-xs\" />\n</div>\n",
-          "react": "<Box>\n  <Input size=\"small\" placeholder=\"small\" m=\"xs\" />\n  <Input size=\"medium\" placeholder=\"medium\" m=\"xs\" />\n  <Input size=\"large\" placeholder=\"large\" m=\"xs\" />\n</Box>;\n",
+          "html": "<div class=\"drac-box\">\n  <input\n    placeholder=\"small\"\n    class=\"drac-input drac-input-sm drac-input-white drac-text-white drac-m-xs\"\n  /><input\n    placeholder=\"medium\"\n    class=\"drac-input drac-input-white drac-text-white drac-m-xs\"\n  /><input\n    placeholder=\"large\"\n    class=\"drac-input drac-input-lg drac-input-white drac-text-white drac-m-xs\"\n  />\n</div>\n",
+          "react": "<Box>\n  <Input color=\"white\" size=\"small\" placeholder=\"small\" m=\"xs\" />\n  <Input color=\"white\" size=\"medium\" placeholder=\"medium\" m=\"xs\" />\n  <Input color=\"white\" size=\"large\" placeholder=\"large\" m=\"xs\" />\n</Box>;\n",
           "docs": "Inputs can be customize to use several different sizes.",
           "screenshot": "./dsp/assets/InputSizes.png"
         },
         {
           "title": "Variants",
-          "html": "<div class=\"drac-box\">\n  <input placeholder=\"normal\" class=\"drac-input drac-m-xs\" /><input\n    placeholder=\"outline\"\n    class=\"drac-input drac-input-outline drac-m-xs\"\n  />\n</div>\n",
-          "react": "<Box>\n  <Input variant=\"normal\" placeholder=\"normal\" m=\"xs\" />\n  <Input variant=\"outline\" placeholder=\"outline\" m=\"xs\" />\n</Box>;\n",
+          "html": "<div class=\"drac-box\">\n  <input\n    placeholder=\"normal\"\n    class=\"drac-input drac-input-white drac-text-white drac-m-xs\"\n  /><input\n    placeholder=\"outline\"\n    class=\"drac-input drac-input-outline drac-input-white drac-text-white drac-m-xs\"\n  />\n</div>\n",
+          "react": "<Box>\n  <Input color=\"white\" variant=\"normal\" placeholder=\"normal\" m=\"xs\" />\n  <Input color=\"white\" variant=\"outline\" placeholder=\"outline\" m=\"xs\" />\n</Box>;\n",
           "docs": "Use the `outline` variant to represent subtler text Inputs",
           "screenshot": "./dsp/assets/InputVariants.png"
+        },
+        {
+          "title": "Type",
+          "html": "<div class=\"drac-box\">\n  <input\n    placeholder=\"Password\"\n    type=\"password\"\n    class=\"drac-input drac-input-white drac-text-white drac-my-sm\"\n  /><input\n    placeholder=\"Date\"\n    type=\"date\"\n    class=\"drac-input drac-input-white drac-text-white drac-my-sm\"\n  /><input\n    placeholder=\"Email\"\n    type=\"email\"\n    class=\"drac-input drac-input-white drac-text-white drac-my-sm\"\n  /><input\n    placeholder=\"Number\"\n    type=\"number\"\n    class=\"drac-input drac-input-white drac-text-white drac-my-sm\"\n  /><input\n    placeholder=\"Range\"\n    type=\"range\"\n    class=\"drac-input drac-input-white drac-text-white drac-my-sm\"\n  /><input\n    placeholder=\"Telephone\"\n    type=\"tel\"\n    class=\"drac-input drac-input-white drac-text-white drac-my-sm\"\n  />\n</div>\n",
+          "react": "<Box>\n  <Input my=\"sm\" color=\"white\" placeholder=\"Password\" type=\"password\" />\n  <Input my=\"sm\" color=\"white\" placeholder=\"Date\" type=\"date\" />\n  <Input my=\"sm\" color=\"white\" placeholder=\"Email\" type=\"email\" />\n  <Input my=\"sm\" color=\"white\" placeholder=\"Number\" type=\"number\" />\n  <Input my=\"sm\" color=\"white\" placeholder=\"Range\" type=\"range\" />\n  <Input my=\"sm\" color=\"white\" placeholder=\"Telephone\" type=\"tel\" />\n</Box>;\n",
+          "docs": "Use the `type` property to define what kind of HTML input you would like to use",
+          "screenshot": "./dsp/assets/InputType.png"
         }
       ],
       "ext_com_draculaui_props": {
@@ -5764,7 +5771,7 @@
           ],
           "required": false,
           "type": {
-            "name": "\"large\" | \"medium\" | \"small\" | undefined"
+            "name": "number | \"large\" | \"medium\" | \"small\" | undefined"
           }
         },
         "variant": {
@@ -5784,6 +5791,25 @@
           "required": false,
           "type": {
             "name": "\"normal\" | \"outline\" | undefined"
+          }
+        },
+        "type": {
+          "defaultValue": null,
+          "description": "Controls the type of the input.",
+          "name": "type",
+          "parent": {
+            "fileName": "src/components/Input/Input.tsx",
+            "name": "InputProps"
+          },
+          "declarations": [
+            {
+              "fileName": "src/components/Input/Input.tsx",
+              "name": "InputProps"
+            }
+          ],
+          "required": false,
+          "type": {
+            "name": "\"number\" | \"hidden\" | \"color\" | \"button\" | \"checkbox\" | \"date\" | \"datetime-local\" | \"email\" | \"file\" | \"image\" | \"month\" | \"password\" | \"radio\" | \"range\" | \"reset\" | \"search\" | ... 6 more ... | undefined"
           }
         },
         "p": {
@@ -6038,7 +6064,7 @@
             ],
             "required": false,
             "type": {
-              "name": "\"large\" | \"medium\" | \"small\" | undefined"
+              "name": "number | \"large\" | \"medium\" | \"small\" | undefined"
             }
           },
           "variant": {
@@ -6058,6 +6084,25 @@
             "required": false,
             "type": {
               "name": "\"normal\" | \"outline\" | undefined"
+            }
+          },
+          "type": {
+            "defaultValue": null,
+            "description": "Controls the type of the input.",
+            "name": "type",
+            "parent": {
+              "fileName": "src/components/Input/Input.tsx",
+              "name": "InputProps"
+            },
+            "declarations": [
+              {
+                "fileName": "src/components/Input/Input.tsx",
+                "name": "InputProps"
+              }
+            ],
+            "required": false,
+            "type": {
+              "name": "\"number\" | \"hidden\" | \"color\" | \"button\" | \"checkbox\" | \"date\" | \"datetime-local\" | \"email\" | \"file\" | \"image\" | \"month\" | \"password\" | \"radio\" | \"range\" | \"reset\" | \"search\" | ... 6 more ... | undefined"
             }
           },
           "p": {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames/dedupe'
-import React, { HTMLAttributes } from 'react'
+import React, { InputHTMLAttributes } from 'react'
 import { ColorMap } from '../../base/colors'
 import {
   cleanProps,
@@ -33,7 +33,7 @@ export const inputColors: Partial<ColorMap> = {
 
 /** Input Props */
 export interface InputProps
-  extends HTMLAttributes<HTMLInputElement>,
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type'>,
     PaddingMixin,
     MarginMixin {
   /**
@@ -44,7 +44,7 @@ export interface InputProps
   /**
    * Controls the size of the input based on pre-configured Dracula UI sizes.
    */
-  size?: keyof typeof inputSizes
+  size?: keyof typeof inputSizes | number
 
   /**
    * Controls the variation the input.
@@ -52,6 +52,33 @@ export interface InputProps
    * `outline` -> Keeps the accent color, but removes the background.
    */
   variant?: keyof typeof inputVariants
+
+  /**
+   * Controls the type of the input.
+   */
+  type?:
+    | 'button'
+    | 'checkbox'
+    | 'color'
+    | 'date'
+    | 'datetime-local'
+    | 'email'
+    | 'file'
+    | 'hidden'
+    | 'image'
+    | 'month'
+    | 'number'
+    | 'password'
+    | 'radio'
+    | 'range'
+    | 'reset'
+    | 'search'
+    | 'submit'
+    | 'tel'
+    | 'text'
+    | 'time'
+    | 'url'
+    | 'week'
 }
 
 /**
@@ -64,17 +91,21 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (props, ref) => {
     const { color, size, variant, ...htmlProps } = props
 
-    const finalProps = {
+    const finalProps: Record<string, any> = {
       ...htmlProps,
       className: cx(
         `drac-input`,
         props.className,
         variant && inputVariants[variant],
-        size && inputSizes[size],
+        size && typeof size === 'string' && inputSizes[size],
         color && inputColors[color],
         ...paddingMixin(props),
         ...marginMixin(props)
       )
+    }
+
+    if (size && typeof size === 'number') {
+      finalProps[size] = size
     }
 
     return <input ref={ref} {...cleanProps(finalProps)} />

--- a/src/components/Input/__tests__/Input.test.tsx
+++ b/src/components/Input/__tests__/Input.test.tsx
@@ -6,11 +6,7 @@ import { Input } from '@/components/Input/Input'
 
 docs(Input, {
   basic() {
-    return snapshot(
-      'Usage',
-      Usage,
-      'Styles or abstracts HTML input elements.'
-    )
+    return snapshot('Usage', Usage, 'Styles or abstracts HTML input elements.')
   },
   variations() {
     return [
@@ -28,14 +24,30 @@ docs(Input, {
         'Variants',
         Variants,
         'Use the `outline` variant to represent subtler text Inputs'
+      ),
+      snapshot(
+        'Type',
+        Types,
+        'Use the `type` property to define what kind of HTML input you would like to use'
       )
     ]
   }
 })
 
 function Usage() {
+  return <Input placeholder="Input" color="white" />
+}
+
+function Types() {
   return (
-    <Input placeholder="Input" color="white" />
+    <Box>
+      <Input my="sm" color="white" placeholder="Password" type="password" />
+      <Input my="sm" color="white" placeholder="Date" type="date" />
+      <Input my="sm" color="white" placeholder="Email" type="email" />
+      <Input my="sm" color="white" placeholder="Number" type="number" />
+      <Input my="sm" color="white" placeholder="Range" type="range" />
+      <Input my="sm" color="white" placeholder="Telephone" type="tel" />
+    </Box>
   )
 }
 
@@ -51,9 +63,9 @@ function Colors() {
 function Sizes() {
   return (
     <Box>
-      <Input size="small" placeholder="small" m="xs" />
-      <Input size="medium" placeholder="medium" m="xs" />
-      <Input size="large" placeholder="large" m="xs" />
+      <Input color="white" size="small" placeholder="small" m="xs" />
+      <Input color="white" size="medium" placeholder="medium" m="xs" />
+      <Input color="white" size="large" placeholder="large" m="xs" />
     </Box>
   )
 }
@@ -61,8 +73,8 @@ function Sizes() {
 function Variants() {
   return (
     <Box>
-      <Input variant="normal" placeholder="normal" m="xs" />
-      <Input variant="outline" placeholder="outline" m="xs" />
+      <Input color="white" variant="normal" placeholder="normal" m="xs" />
+      <Input color="white" variant="outline" placeholder="outline" m="xs" />
     </Box>
   )
 }

--- a/src/components/Input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -40,19 +40,69 @@ exports[`Site: Input Sizes 1`] = `
 Object {
   "docs": "Inputs can be customize to use several different sizes.",
   "html": "<div class=\\"drac-box\\">
-  <input placeholder=\\"small\\" class=\\"drac-input drac-input-sm drac-m-xs\\" /><input
+  <input
+    placeholder=\\"small\\"
+    class=\\"drac-input drac-input-sm drac-input-white drac-text-white drac-m-xs\\"
+  /><input
     placeholder=\\"medium\\"
-    class=\\"drac-input drac-m-xs\\"
-  /><input placeholder=\\"large\\" class=\\"drac-input drac-input-lg drac-m-xs\\" />
+    class=\\"drac-input drac-input-white drac-text-white drac-m-xs\\"
+  /><input
+    placeholder=\\"large\\"
+    class=\\"drac-input drac-input-lg drac-input-white drac-text-white drac-m-xs\\"
+  />
 </div>
 ",
   "react": "<Box>
-  <Input size=\\"small\\" placeholder=\\"small\\" m=\\"xs\\" />
-  <Input size=\\"medium\\" placeholder=\\"medium\\" m=\\"xs\\" />
-  <Input size=\\"large\\" placeholder=\\"large\\" m=\\"xs\\" />
+  <Input color=\\"white\\" size=\\"small\\" placeholder=\\"small\\" m=\\"xs\\" />
+  <Input color=\\"white\\" size=\\"medium\\" placeholder=\\"medium\\" m=\\"xs\\" />
+  <Input color=\\"white\\" size=\\"large\\" placeholder=\\"large\\" m=\\"xs\\" />
 </Box>;
 ",
   "title": "Sizes",
+}
+`;
+
+exports[`Site: Input Type 1`] = `
+Object {
+  "docs": "Use the \`type\` property to define what kind of HTML input you would like to use",
+  "html": "<div class=\\"drac-box\\">
+  <input
+    placeholder=\\"Password\\"
+    type=\\"password\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-my-sm\\"
+  /><input
+    placeholder=\\"Date\\"
+    type=\\"date\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-my-sm\\"
+  /><input
+    placeholder=\\"Email\\"
+    type=\\"email\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-my-sm\\"
+  /><input
+    placeholder=\\"Number\\"
+    type=\\"number\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-my-sm\\"
+  /><input
+    placeholder=\\"Range\\"
+    type=\\"range\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-my-sm\\"
+  /><input
+    placeholder=\\"Telephone\\"
+    type=\\"tel\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-my-sm\\"
+  />
+</div>
+",
+  "react": "<Box>
+  <Input my=\\"sm\\" color=\\"white\\" placeholder=\\"Password\\" type=\\"password\\" />
+  <Input my=\\"sm\\" color=\\"white\\" placeholder=\\"Date\\" type=\\"date\\" />
+  <Input my=\\"sm\\" color=\\"white\\" placeholder=\\"Email\\" type=\\"email\\" />
+  <Input my=\\"sm\\" color=\\"white\\" placeholder=\\"Number\\" type=\\"number\\" />
+  <Input my=\\"sm\\" color=\\"white\\" placeholder=\\"Range\\" type=\\"range\\" />
+  <Input my=\\"sm\\" color=\\"white\\" placeholder=\\"Telephone\\" type=\\"tel\\" />
+</Box>;
+",
+  "title": "Type",
 }
 `;
 
@@ -60,15 +110,18 @@ exports[`Site: Input Variants 1`] = `
 Object {
   "docs": "Use the \`outline\` variant to represent subtler text Inputs",
   "html": "<div class=\\"drac-box\\">
-  <input placeholder=\\"normal\\" class=\\"drac-input drac-m-xs\\" /><input
+  <input
+    placeholder=\\"normal\\"
+    class=\\"drac-input drac-input-white drac-text-white drac-m-xs\\"
+  /><input
     placeholder=\\"outline\\"
-    class=\\"drac-input drac-input-outline drac-m-xs\\"
+    class=\\"drac-input drac-input-outline drac-input-white drac-text-white drac-m-xs\\"
   />
 </div>
 ",
   "react": "<Box>
-  <Input variant=\\"normal\\" placeholder=\\"normal\\" m=\\"xs\\" />
-  <Input variant=\\"outline\\" placeholder=\\"outline\\" m=\\"xs\\" />
+  <Input color=\\"white\\" variant=\\"normal\\" placeholder=\\"normal\\" m=\\"xs\\" />
+  <Input color=\\"white\\" variant=\\"outline\\" placeholder=\\"outline\\" m=\\"xs\\" />
 </Box>;
 ",
   "title": "Variants",


### PR DESCRIPTION
This change adds support and autocomplete for different input types.
By adding `type` as a top level option, we now also pave the way for any potential overrides to inputs that we may want to make.

Closes: https://github.com/dracula/dracula-ui/issues/79