### PR TITLE
Update NextJS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,11 @@ export default MyApp
 Then you can import Dracula UI and use all React components.
 
 ```jsx
-import { Component } from 'react'
 import { Paragraph } from '@dracula/dracula-ui'
 
-class Index extends Component {
-  render() {
-    return <Paragraph color="black">Hello Vampire</Paragraph>
-  }
+export default function Index() {
+  return <Paragraph color="black">Hello Vampire</Paragraph>
 }
-
-export default Index
 ```
 
 > [See full example](https://github.com/dracula/dracula-ui/tree/master/examples/with-next).

--- a/examples/with-next/pages/index.js
+++ b/examples/with-next/pages/index.js
@@ -1,10 +1,5 @@
-import { Component } from 'react'
 import { Paragraph } from '@dracula/dracula-ui'
 
-class Index extends Component {
-  render() {
-    return <Paragraph color="black">Hello Vampire</Paragraph>
-  }
+export default function Index() {
+  return <Paragraph color="black">Hello Vampire</Paragraph>
 }
-
-export default Index


### PR DESCRIPTION
It uses the more common approach without the 'extends Component' and
'import react' because it isn't required in the new versions of React/NextJS.