### PR TITLE
Add isExternal prop to Anchor component

### DIFF
--- a/dsp/data/components.json
+++ b/dsp/data/components.json
@@ -49,6 +49,13 @@
           "react": "<Box style={{ display: \"flex\", flexDirection: \"column\" }}>\n  <Anchor href=\"#\" size=\"xs\" mb=\"sm\">\n    xs\n  </Anchor>\n  <Anchor href=\"#\" size=\"sm\" mb=\"sm\">\n    sm\n  </Anchor>\n  <Anchor href=\"#\" size=\"md\" mb=\"sm\">\n    md\n  </Anchor>\n  <Anchor href=\"#\" size=\"lg\" mb=\"sm\">\n    lg\n  </Anchor>\n</Box>;\n",
           "docs": "Anchors can be customize to use several different sizes.",
           "screenshot": "./dsp/assets/AnchorSizes.png"
+        },
+        {
+          "title": "External",
+          "html": "<a\n  target=\"_blank\"\n  rel=\"noopener noreferrer\"\n  href=\"https://www.google.com/search?q=count+dracula\"\n  class=\"drac-anchor drac-text drac-text-white drac-text-purple--hover\"\n  >Find Dracula on Google</a\n>\n",
+          "react": "<Anchor href=\"https://www.google.com/search?q=count+dracula\" isExternal={true}>\n  Find Dracula on Google\n</Anchor>;\n",
+          "docs": "The isExternal prop can be used to apply external link props such as target=\"_blank\"",
+          "screenshot": "./dsp/assets/AnchorExternal.png"
         }
       ],
       "ext_com_draculaui_props": {
@@ -145,6 +152,25 @@
           "required": false,
           "type": {
             "name": "\"purpleCyan\" | \"yellowPink\" | \"cyanGreen\" | \"pinkPurple\" | \"cyan\" | \"green\" | \"orange\" | \"pink\" | \"purple\" | \"red\" | \"yellow\" | \"white\" | \"black\" | \"blackSecondary\" | \"blackLight\" | undefined"
+          }
+        },
+        "isExternal": {
+          "defaultValue": null,
+          "description": "Whether or not to apply external link props such as `target=\"_blank\"` and `rel=\"noopener noreferrer\"`",
+          "name": "isExternal",
+          "parent": {
+            "fileName": "src/components/Anchor/Anchor.tsx",
+            "name": "AnchorProps"
+          },
+          "declarations": [
+            {
+              "fileName": "src/components/Anchor/Anchor.tsx",
+              "name": "AnchorProps"
+            }
+          ],
+          "required": false,
+          "type": {
+            "name": "boolean | undefined"
           }
         },
         "p": {
@@ -457,6 +483,25 @@
             "required": false,
             "type": {
               "name": "\"purpleCyan\" | \"yellowPink\" | \"cyanGreen\" | \"pinkPurple\" | \"cyan\" | \"green\" | \"orange\" | \"pink\" | \"purple\" | \"red\" | \"yellow\" | \"white\" | \"black\" | \"blackSecondary\" | \"blackLight\" | undefined"
+            }
+          },
+          "isExternal": {
+            "defaultValue": null,
+            "description": "Whether or not to apply external link props such as `target=\"_blank\"` and `rel=\"noopener noreferrer\"`",
+            "name": "isExternal",
+            "parent": {
+              "fileName": "src/components/Anchor/Anchor.tsx",
+              "name": "AnchorProps"
+            },
+            "declarations": [
+              {
+                "fileName": "src/components/Anchor/Anchor.tsx",
+                "name": "AnchorProps"
+              }
+            ],
+            "required": false,
+            "type": {
+              "name": "boolean | undefined"
             }
           },
           "p": {

--- a/src/components/Anchor/Anchor.tsx
+++ b/src/components/Anchor/Anchor.tsx
@@ -43,6 +43,11 @@ export interface AnchorProps
    * Controls the color of the link on hover
    */
   hoverColor?: keyof typeof hoverColors
+
+  /**
+   * Whether or not to apply external link props such as `target="_blank"` and `rel="noopener noreferrer"`
+   */
+  isExternal?: boolean
 }
 
 /**
@@ -55,7 +60,7 @@ export interface AnchorProps
  */
 export const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProps>(
   (props, ref) => {
-    const { size, weight, color, hoverColor, ...htmlProps } = props
+    const { size, weight, color, hoverColor, isExternal, ...htmlProps } = props
 
     const finalProps = cleanProps({
       ...htmlProps,
@@ -73,7 +78,12 @@ export const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProps>(
     })
 
     return (
-      <a ref={ref} {...finalProps}>
+      <a
+        ref={ref}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+        {...finalProps}
+      >
         {props.children}
       </a>
     )

--- a/src/components/Anchor/__tests__/Anchor.test.tsx
+++ b/src/components/Anchor/__tests__/Anchor.test.tsx
@@ -29,22 +29,31 @@ docs(Anchor, {
         Sizes,
         'Anchors can be customize to use several different sizes.'
       ),
+      snapshot(
+        'External',
+        External,
+        'The isExternal prop can be used to apply external link props such as target="_blank"'
+      )
     ]
   }
 })
 
 function Usage() {
-  return (
-    <Anchor href="#">Visit the Dracula Castle</Anchor>
-  )
+  return <Anchor href="#">Visit the Dracula Castle</Anchor>
 }
 
 function Weights() {
   return (
     <Box style={{ display: 'flex', flexDirection: 'column' }}>
-      <Anchor href="#" weight="normal" mb="sm">normal</Anchor>
-      <Anchor href="#" weight="semibold" mb="sm">semibold</Anchor>
-      <Anchor href="#" weight="bold" mb="sm">bold</Anchor>
+      <Anchor href="#" weight="normal" mb="sm">
+        normal
+      </Anchor>
+      <Anchor href="#" weight="semibold" mb="sm">
+        semibold
+      </Anchor>
+      <Anchor href="#" weight="bold" mb="sm">
+        bold
+      </Anchor>
     </Box>
   )
 }
@@ -52,10 +61,18 @@ function Weights() {
 function Sizes() {
   return (
     <Box style={{ display: 'flex', flexDirection: 'column' }}>
-      <Anchor href="#" size="xs" mb="sm">xs</Anchor>
-      <Anchor href="#" size="sm" mb="sm">sm</Anchor>
-      <Anchor href="#" size="md" mb="sm">md</Anchor>
-      <Anchor href="#" size="lg" mb="sm">lg</Anchor>
+      <Anchor href="#" size="xs" mb="sm">
+        xs
+      </Anchor>
+      <Anchor href="#" size="sm" mb="sm">
+        sm
+      </Anchor>
+      <Anchor href="#" size="md" mb="sm">
+        md
+      </Anchor>
+      <Anchor href="#" size="lg" mb="sm">
+        lg
+      </Anchor>
     </Box>
   )
 }
@@ -73,3 +90,12 @@ function Colors() {
     </div>
   )
 }
+
+function External() {
+  return (
+    <Anchor href="https://www.google.com/search?q=count+dracula" isExternal>
+      Find Dracula on Google
+    </Anchor>
+  )
+}
+

--- a/src/components/Anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
+++ b/src/components/Anchor/__tests__/__snapshots__/Anchor.test.tsx.snap
@@ -43,6 +43,25 @@ Object {
 }
 `;
 
+exports[`Site: Anchor External 1`] = `
+Object {
+  "docs": "The isExternal prop can be used to apply external link props such as target=\\"_blank\\"",
+  "html": "<a
+  target=\\"_blank\\"
+  rel=\\"noopener noreferrer\\"
+  href=\\"https://www.google.com/search?q=count+dracula\\"
+  class=\\"drac-anchor drac-text drac-text-white drac-text-purple--hover\\"
+  >Find Dracula on Google</a
+>
+",
+  "react": "<Anchor href=\\"https://www.google.com/search?q=count+dracula\\" isExternal={true}>
+  Find Dracula on Google
+</Anchor>;
+",
+  "title": "External",
+}
+`;
+
 exports[`Site: Anchor Sizes 1`] = `
 Object {
   "docs": "Anchors can be customize to use several different sizes.",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -40,7 +40,7 @@
     to-fast-properties "^2.0.0"
 
 "@dracula/dracula-ui@file:../dist":
-  version "0.7.6"
+  version "0.7.8"
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.20"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11819124/117513183-1d300a00-af89-11eb-8624-11102df426c6.png)
![image](https://user-images.githubusercontent.com/11819124/117513193-21f4be00-af89-11eb-823d-97e2159becfc.png)

This introduces an `isExternal` prop to the Anchor element, which will apply:

```
target="_blank" rel="noopener noreferrer"
```

Which are super handy for linking to external sites, the noopener noreferrer stuff is outlined pretty well [here](https://www.reliablesoft.net/noreferrer-noopener/) and the target="_blank" will open the link in a new tab