### PR TITLE
Fix background colors for Avatar with image

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -88,12 +88,16 @@ export const Avatar = (props: AvatarProps) => {
     ...props.style
   }
 
-  if (props.src) {
-    style.backgroundImage = `url('${props.src}')`
-  }
-
   return (
     <span className={classes} style={style} {...cleanProps(htmlProps)}>
+      {props.src && (
+        <span
+          className={cx('drac-avatar-background')}
+          style={{
+            backgroundImage: `url('${props.src}')`
+          }}
+        />
+      )}
       {!props.src && (
         <Text color={props.color ?? 'white'}>
           {f}

--- a/src/styles/avatar.css
+++ b/src/styles/avatar.css
@@ -17,10 +17,19 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
 
+.avatar-background {
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
+
+  box-sizing: border-box;
+  border-radius: var(--rounded-full);
+
+  display: 'inline-block';
+  height: 100%;
+  width: 100%;
 }
 
 .avatar-lg-stroke {


### PR DESCRIPTION
It turns out that our text and background colors were clashing
with the background-image property for avatars.

Closes https://github.com/dracula/dracula-ui/issues/102