### PR TITLE
Fix reference to old package

### DIFF
--- a/website/pages/migration.js
+++ b/website/pages/migration.js
@@ -44,7 +44,7 @@ class Migration extends React.Component {
         <Box my="lg">
           <Heading size="heading-2">2. Update package.json</Heading>
           <Paragraph>
-            Update your local package.json file to use the new package name which is <Box as="code" className="drac-text-pink">dracula-ui</Box> instead of <Box as="code" className="drac-text-pink">dracula-ui</Box>.
+            Update your local package.json file to use the new package name which is <Box as="code" className="drac-text-pink">dracula-ui</Box> instead of <Box as="code" className="drac-text-pink">@dracula/dracula-ui</Box>.
           </Paragraph>
           <Paragraph>
             You'll also have to bump the version to <Box as="code" className="drac-text-pink">1.0.0</Box> which only contains the package rename and no breaking changes.


### PR DESCRIPTION
Old package was being referenced as `dracula-ui`, without the scope `@dracula`. This PR fixes the reference

On https://ui.draculatheme.com/migration:
> Update your local package.json file to use the new package name which is dracula-ui instead of dracula-ui.