### PR TITLE
Replace branch name: master -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Now you can take advantage of all the classes, for example:
 <p class="drac-text drac-text-black">Hello Vampire</p>
 ```
 
-> [See full example](https://github.com/dracula/dracula-ui/tree/master/examples/with-html).
+> [See full example](https://github.com/dracula/dracula-ui/tree/main/examples/with-html).
 
 ## :sparkles: Using with React
 
@@ -58,7 +58,7 @@ function App() {
 export default App;
 ```
 
-> [See full example](https://github.com/dracula/dracula-ui/tree/master/examples/with-react).
+> [See full example](https://github.com/dracula/dracula-ui/tree/main/examples/with-react).
 
 ## :rocket: Using with Next.js
 
@@ -86,7 +86,7 @@ export default function Index() {
 }
 ```
 
-> [See full example](https://github.com/dracula/dracula-ui/tree/master/examples/with-next).
+> [See full example](https://github.com/dracula/dracula-ui/tree/main/examples/with-next).
 
 ## :test_tube: Using with Jekyll
 
@@ -113,7 +113,7 @@ Finally, include the compiled CSS file into your `_layouts`.
 <link rel="stylesheet" href="/assets/css/styles.css">
 ```
 
-> [See full example](https://github.com/dracula/dracula-ui/tree/master/examples/with-jekyll).
+> [See full example](https://github.com/dracula/dracula-ui/tree/main/examples/with-jekyll).
 
 ## :bulb: Ideas
 

--- a/website/pages/design.js
+++ b/website/pages/design.js
@@ -26,7 +26,7 @@ class Design extends React.Component {
             components on Figma.
           </Paragraph>
           <Paragraph>
-            You can find the <code>.fig</code> file inside the <Anchor target="_blank" href="https://github.com/dracula/dracula-ui/tree/master/design">design</Anchor> folder.
+            You can find the <code>.fig</code> file inside the <Anchor target="_blank" href="https://github.com/dracula/dracula-ui/tree/main/design">design</Anchor> folder.
           </Paragraph>
           <img
             className={styles.image}

--- a/website/pages/installation.js
+++ b/website/pages/installation.js
@@ -50,7 +50,7 @@ yarn add dracula-ui`}
             code={`<p class="drac-text drac-text-black">Hello Vampire</p>`}
           />
           <Paragraph>
-            <Anchor href="https://github.com/dracula/dracula-ui/tree/master/examples/with-html">See full example</Anchor>
+            <Anchor href="https://github.com/dracula/dracula-ui/tree/main/examples/with-html">See full example</Anchor>
           </Paragraph>
         </Box>
         <Box my="lg">
@@ -72,7 +72,7 @@ export default App;
 `}
           />
           <Paragraph>
-            <Anchor href="https://github.com/dracula/dracula-ui/tree/master/examples/with-react">See full example</Anchor>
+            <Anchor href="https://github.com/dracula/dracula-ui/tree/main/examples/with-react">See full example</Anchor>
           </Paragraph>
         </Box>
         <Box my="lg">
@@ -112,7 +112,7 @@ class Index extends Component {
 export default Index`}
           />
           <Paragraph>
-            <Anchor href="https://github.com/dracula/dracula-ui/tree/master/examples/with-next">See full example</Anchor>
+            <Anchor href="https://github.com/dracula/dracula-ui/tree/main/examples/with-next">See full example</Anchor>
           </Paragraph>
         </Box>
         <Box my="lg">
@@ -145,7 +145,7 @@ export default Index`}
             code={`<link rel="stylesheet" href="/assets/css/styles.css">`}
           />
           <Paragraph>
-            <Anchor href="https://github.com/dracula/dracula-ui/tree/master/examples/with-jekyll">See full example</Anchor>
+            <Anchor href="https://github.com/dracula/dracula-ui/tree/main/examples/with-jekyll">See full example</Anchor>
           </Paragraph>
         </Box>
       </Box>

--- a/website/pages/migration.js
+++ b/website/pages/migration.js
@@ -44,7 +44,7 @@ class Migration extends React.Component {
         <Box my="lg">
           <Heading size="heading-2">2. Update package.json</Heading>
           <Paragraph>
-            Update your local package.json file to use the new package name which is <Box as="code" className="drac-text-pink">dracula-ui</Box> instead of <Box as="code" className="drac-text-pink">dracula-ui</Box>.
+            Update your local package.json file to use the new package name which is <Box as="code" className="drac-text-pink">dracula-ui</Box> instead of <Box as="code" className="drac-text-pink">@dracula/dracula-ui</Box>.
           </Paragraph>
           <Paragraph>
             You'll also have to bump the version to <Box as="code" className="drac-text-pink">1.0.0</Box> which only contains the package rename and no breaking changes.

--- a/website/pages/welcome.js
+++ b/website/pages/welcome.js
@@ -45,8 +45,8 @@ class Welcome extends React.Component {
           <List variant="unordered" color="white" p="none" mb="sm">
             <li><Anchor href="https://github.com/dracula/dracula-ui">GitHub</Anchor></li>
             <li><Anchor href="https://discord.gg/vyA9AdqdbK">Discord</Anchor></li>
-            <li><Anchor href="https://github.com/dracula/dracula-ui/tree/master/design">Figma</Anchor></li>
-            <li><Anchor href="https://github.com/dracula/dracula-ui/blob/master/LICENSE.md">License</Anchor></li>
+            <li><Anchor href="https://github.com/dracula/dracula-ui/tree/main/design">Figma</Anchor></li>
+            <li><Anchor href="https://github.com/dracula/dracula-ui/blob/main/LICENSE">License</Anchor></li>
           </List>
 
           <List variant="unordered" color="white" p="none">


### PR DESCRIPTION
With the main branch renamed `master` -> `main`, there were some references to the old branch name. This PR replaces the the old name with the new one