### PR TITLE
Add numbering type for OrderedList

### DIFF
--- a/dsp/data/css.json
+++ b/dsp/data/css.json
@@ -2616,6 +2616,96 @@
     {
       "class": "component",
       "type": "page",
+      "id": ".drac-list-ordered-decimal",
+      "name": ".drac-list-ordered-decimal",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-list-ordered-decimal",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-list-ordered-decimal",
+        "languages": {
+          "css": "drac-list-ordered-decimal"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-list-ordered-lower-alpha",
+      "name": ".drac-list-ordered-lower-alpha",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-list-ordered-lower-alpha",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-list-ordered-lower-alpha",
+        "languages": {
+          "css": "drac-list-ordered-lower-alpha"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-list-ordered-lower-roman",
+      "name": ".drac-list-ordered-lower-roman",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-list-ordered-lower-roman",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-list-ordered-lower-roman",
+        "languages": {
+          "css": "drac-list-ordered-lower-roman"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-list-ordered-upper-alpha",
+      "name": ".drac-list-ordered-upper-alpha",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-list-ordered-upper-alpha",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-list-ordered-upper-alpha",
+        "languages": {
+          "css": "drac-list-ordered-upper-alpha"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-list-ordered-upper-roman",
+      "name": ".drac-list-ordered-upper-roman",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-list-ordered-upper-roman",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-list-ordered-upper-roman",
+        "languages": {
+          "css": "drac-list-ordered-upper-roman"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
       "id": ".drac-list-pink",
       "name": ".drac-list-pink",
       "last_updated_by": "System",

--- a/src/components/OrderedList/OrderedList.tsx
+++ b/src/components/OrderedList/OrderedList.tsx
@@ -20,6 +20,14 @@ export const orderedListColors: Partial<ColorMap> = {
   yellow: 'drac-list-yellow'
 }
 
+const orderedListTypes = {
+  1: 'drac-list-ordered-decimal',
+  a: 'drac-list-ordered-lower-alpha',
+  A: 'drac-list-ordered-lower-alpha',
+  i: 'drac-list-ordered-lower-roman',
+  I: 'drac-list-ordered-lower-roman'
+}
+
 /**
  * OrderedList Props
  */
@@ -29,18 +37,22 @@ export interface OrderedListProps
     MarginMixin {
   /** The Dracula UI color for the Ordered List. */
   color?: keyof typeof orderedListColors
+  /** The numbering type of the Ordered List, same as a regular `<ol>` element. */
+  type?: OlHTMLAttributes<HTMLOListElement>['type']
 }
 
 /**
  * Ordered Lists are used to display list items in an ordered way.
  */
 export const OrderedList: React.FC<OrderedListProps> = (props) => {
-  const { color, ...htmlProps } = props
+  const { color, type, ...htmlProps } = props
 
   const finalProps = cleanProps({
     ...htmlProps,
+    type,
     className: cx(
       'drac-list drac-list-ordered',
+      type && orderedListTypes[type],
       props.className,
       color && orderedListColors[color],
       ...paddingMixin(props),

--- a/src/components/OrderedList/__tests__/OrderedList.test.tsx
+++ b/src/components/OrderedList/__tests__/OrderedList.test.tsx
@@ -13,6 +13,11 @@ docs(OrderedList, {
         'Colors',
         Colors,
         'OrderedLists can be customized to use any of the Dracula UI theme colors.'
+      ),
+      snapshot(
+        'Types',
+        Types,
+        'OrderedLists can have a numbering type similar to an <ol> element.'
       )
     ]
   }
@@ -31,6 +36,16 @@ function Usage() {
 function Colors() {
   return (
     <OrderedList color="cyan">
+      <li className="drac-text drac-text-white">Blade</li>
+      <li className="drac-text drac-text-white">Buffy</li>
+      <li className="drac-text drac-text-white">Morbius</li>
+    </OrderedList>
+  )
+}
+
+function Types() {
+  return (
+    <OrderedList color="cyan" type="A">
       <li className="drac-text drac-text-white">Blade</li>
       <li className="drac-text drac-text-white">Buffy</li>
       <li className="drac-text drac-text-white">Morbius</li>

--- a/src/components/OrderedList/__tests__/__snapshots__/OrderedList.test.tsx.snap
+++ b/src/components/OrderedList/__tests__/__snapshots__/OrderedList.test.tsx.snap
@@ -37,3 +37,25 @@ Object {
   "title": "Colors",
 }
 `;
+
+exports[`Site: OrderedList Types 1`] = `
+Object {
+  "docs": "OrderedLists can have a numbering type similar to an <ol> element.",
+  "html": "<ol
+  type=\\"A\\"
+  class=\\"drac-list drac-list-ordered drac-list-ordered-lower-alpha drac-list-cyan\\"
+>
+  <li class=\\"drac-text drac-text-white\\">Blade</li>
+  <li class=\\"drac-text drac-text-white\\">Buffy</li>
+  <li class=\\"drac-text drac-text-white\\">Morbius</li>
+</ol>
+",
+  "react": "<OrderedList color=\\"cyan\\" type=\\"A\\">
+  <li className=\\"drac-text drac-text-white\\">Blade</li>
+  <li className=\\"drac-text drac-text-white\\">Buffy</li>
+  <li className=\\"drac-text drac-text-white\\">Morbius</li>
+</OrderedList>;
+",
+  "title": "Types",
+}
+`;

--- a/src/styles/list.css
+++ b/src/styles/list.css
@@ -11,13 +11,33 @@
   counter-reset: li;
 }
 
+.list-ordered-lower-alpha {
+  --type: lower-alpha;
+}
+
+.list-ordered-upper-alpha {
+  --type: upper-alpha;
+}
+
+.list-ordered-lower-roman {
+  --type: lower-roman;
+}
+
+.list-ordered-upper-roman {
+  --type: upper-roman;
+}
+
+.list-ordered-decimal {
+  --type: decimal;
+}
+
 .list-ordered li {
   counter-increment: li;
   margin-left: -30px;
 }
 
 .list-ordered li::before {
-  content: counter(li)'.';
+  content: counter(li, var(--type, decimal))'.';
   display: inline-block;
   margin-left: 15px;
   padding-right: 5px;


### PR DESCRIPTION
Closes #129

I added additional styles for the `OrderedList` component, using a CSS variable to set the content of the `OrderedList` item's marker.

For now, I simply created additional classes to set the CSS variable, one for [each possible `type` attribute for an `<ol>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol#attr-type):

```ts
const orderedListTypes = {
  1: 'drac-list-ordered-decimal',
  a: 'drac-list-ordered-lower-alpha',
  A: 'drac-list-ordered-lower-alpha',
  i: 'drac-list-ordered-lower-roman',
  I: 'drac-list-ordered-lower-roman'
}
```

Ideally we should be able to simply use attribute selectors ([with a case-sensitive modifier](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#attr_operator_value_s)) to set the CSS variable, but this solution only works on Firefox as of now:

```css
.list-ordered[type="a" s] {
  --type: lower-alpha;
}

.list-ordered[type="A" s] {
  --type: upper-alpha;
}
```

**Notes**

I was able to run the tests, but I don't seem to be able to generate new docs pages for my changes. For now I just manually tested my changes directly using the browser, and my changes at least seem to be properly reflected on the build outputs and the snapshot tests.