### PR TITLE
Add-new-color

### DIFF
--- a/dsp/data/css.json
+++ b/dsp/data/css.json
@@ -384,6 +384,60 @@
     {
       "class": "component",
       "type": "page",
+      "id": ".drac-bg-grey",
+      "name": ".drac-bg-grey",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-bg-grey",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-bg-grey",
+        "languages": {
+          "css": "drac-bg-grey"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-bg-grey-secondary",
+      "name": ".drac-bg-grey-secondary",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-bg-grey-secondary",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-bg-grey-secondary",
+        "languages": {
+          "css": "drac-bg-grey-secondary"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-bg-grey-transparent",
+      "name": ".drac-bg-grey-transparent",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-bg-grey-transparent",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-bg-grey-transparent",
+        "languages": {
+          "css": "drac-bg-grey-transparent"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
       "id": ".drac-bg-orange",
       "name": ".drac-bg-orange",
       "last_updated_by": "System",
@@ -864,6 +918,24 @@
         "trigger": "css-border-green",
         "languages": {
           "css": "drac-border-green"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-border-grey",
+      "name": ".drac-border-grey",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-border-grey",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-border-grey",
+        "languages": {
+          "css": "drac-border-grey"
         }
       }
     },
@@ -1548,6 +1620,24 @@
         "trigger": "css-glow-green",
         "languages": {
           "css": "drac-glow-green"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-glow-grey",
+      "name": ".drac-glow-grey",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-glow-grey",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-glow-grey",
+        "languages": {
+          "css": "drac-glow-grey"
         }
       }
     },
@@ -4740,6 +4830,24 @@
     {
       "class": "component",
       "type": "page",
+      "id": ".drac-scrollbar-grey",
+      "name": ".drac-scrollbar-grey",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-scrollbar-grey",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-scrollbar-grey",
+        "languages": {
+          "css": "drac-scrollbar-grey"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
       "id": ".drac-scrollbar-orange",
       "name": ".drac-scrollbar-orange",
       "last_updated_by": "System",
@@ -5994,6 +6102,42 @@
         "trigger": "css-text-green--hover",
         "languages": {
           "css": "drac-text-green--hover"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-text-grey",
+      "name": ".drac-text-grey",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-text-grey",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-text-grey",
+        "languages": {
+          "css": "drac-text-grey"
+        }
+      }
+    },
+    {
+      "class": "component",
+      "type": "page",
+      "id": ".drac-text-grey-secondary",
+      "name": ".drac-text-grey-secondary",
+      "last_updated_by": "System",
+      "description": "CSS class containing .drac-text-grey-secondary",
+      "related_entity_ids": [],
+      "tags": [
+        "component"
+      ],
+      "snippets": {
+        "trigger": "css-text-grey-secondary",
+        "languages": {
+          "css": "drac-text-grey-secondary"
         }
       }
     },

--- a/src/base/colors.ts
+++ b/src/base/colors.ts
@@ -4,7 +4,10 @@ export const supportColors = {
   white: 'drac-bg-white',
   black: 'drac-bg-black',
   blackSecondary: 'drac-bg-black-secondary',
-  blackLight: 'drac-bg-black-light'
+  blackLight: 'drac-bg-black-light',
+  grey: 'drac-bg-grey',
+  greySecondary: 'drac-bg-grey-secondary',
+  greyLight: 'drac-bg-grey-light'
 }
 
 export const baseColors = {
@@ -63,8 +66,8 @@ export const baseTextColors: ColorMap = mapValues(colors, (className) => {
   return className.replace('-bg-', '-text-')
 })
 
-export const scrollbarColors: BaseColorMap = mapValues(
-  baseColors,
+export const scrollbarColors: ColorMap = mapValues(
+  colors,
   (className) => {
     return className.replace('-bg-', '-scrollbar-')
   }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -4,6 +4,11 @@
   --blackTernary: hsl(230, 15%, 70%);
   --blackLight: hsla(230, 15%, 15%, 5%);
 
+  --grey: hsl(230, 15%, 30%);
+  --greySecondary: hsl(230, 15%, 45%);
+  --greyTernary: hsl(230, 15%, 75%);
+  --greyLight: hsla(230, 15%, 30%, 5%);
+
   --white: hsl(60, 30%, 96%);
   --whiteSecondary: hsl(60, 30%, 100%);
   --whiteLight: hsla(60, 30%, 96%, 5%);
@@ -106,7 +111,7 @@
   }
 }
 
-@each $color in black, white, cyan, green, orange, pink, purple, red, yellow {
+@each $color in black, grey, white, cyan, green, orange, pink, purple, red, yellow {
   .bg-$(color) {
     background-color: var(--$(color));
   }

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -1,4 +1,4 @@
-@each $color in cyan, green, orange, pink, purple, red, yellow {
+@each $color in grey, cyan, green, orange, pink, purple, red, yellow {
   .scrollbar-$(color) {
     --drac-scrollbar-bg: transparent;
     --drac-scrollbar-border: var(--$(color)Light);

--- a/website/components/Navigation.module.css
+++ b/website/components/Navigation.module.css
@@ -1,4 +1,5 @@
 .nav {
+  composes: drac-scrollbar-grey from global;
   background: #15171b;
   height: 100vh;
   min-width: 15rem;

--- a/website/components/Tabs.module.css
+++ b/website/components/Tabs.module.css
@@ -23,6 +23,7 @@
 
 .usage,
 .codeContainer {
+  composes: drac-scrollbar-grey from global;
   background: #282a36;
   border-radius: var(--rounded-md);
   max-height: 300px;

--- a/website/pages/_document.js
+++ b/website/pages/_document.js
@@ -1,7 +1,7 @@
-import React from "react";
-import Document, { Html, Head, Main, NextScript } from "next/document";
+import Document, { Head, Html, Main, NextScript } from "next/document";
 
 import { GA_TRACKING_ID } from "../lib/gtag";
+import React from "react";
 
 export default class extends Document {
   static async getInitialProps(ctx) {
@@ -17,7 +17,10 @@ export default class extends Document {
           <meta property="og:type" content="website" />
           <meta content="summary_large_image" name="twitter:card" />
           <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
-          <meta content="https://ui.draculatheme.com/static/og.jpg" property="og:image" />
+          <meta
+            content="https://ui.draculatheme.com/static/og.jpg"
+            property="og:image"
+          />
           <meta content="Netto Farah &amp; Zeno Rocha" name="author" />
 
           <script
@@ -31,13 +34,15 @@ export default class extends Document {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '${GA_TRACKING_ID}');
-          `,
+          `
             }}
           />
         </Head>
-        <Main />
-        <NextScript />
+        <body className="drac-scrollbar-grey">
+          <Main />
+          <NextScript />
+        </body>
       </Html>
-    );
+    )
   }
 }


### PR DESCRIPTION
The documentation scrollbar on Windows devices is not very pretty, so I added it; however, the available colours drew a lot of attention from the content. 😥

Then I added the colour `grey`, for a more subtle look. ✨

✅ _Commits are separated in colour inclusion and scrollbar inclusion._