### PR TITLE
🐛 Fix `On this page` component overlap

### DIFF
--- a/website/components/DocsOverview.js
+++ b/website/components/DocsOverview.js
@@ -1,19 +1,11 @@
-import React from 'react'
 import { Anchor, Box, Text } from 'dracula-ui'
+
+import React from 'react'
+import localStyles from './DocsOverview.module.css'
 
 export function DocsOverview({ sections, showProperties }) {
   return (
-    <Box
-      as="ul"
-      style={{
-        position: 'fixed',
-        right: '80px',
-        top: '64px',
-        margin: 0,
-        maxHeight: '80vh',
-        overflowY: 'auto'
-      }}
-    >
+    <Box as="ul" className={localStyles.docsOverview}>
       <Text weight="semibold" style={{ textTransform: 'uppercase' }}>
         On this page
       </Text>

--- a/website/components/DocsOverview.module.css
+++ b/website/components/DocsOverview.module.css
@@ -1,0 +1,18 @@
+.docsOverview {
+    max-height: 80vh;
+    margin: 0;
+    position: fixed;
+    overflow-y: auto;
+    top: 64px;
+    right: 80px;
+}
+
+@media (max-width: 76rem){
+    .docsOverview{
+        width: 100%;
+        margin: 3.75rem 0 0 0;
+        padding: 0;
+        position: relative;
+        inset: unset;
+    }
+}


### PR DESCRIPTION
The `DocsOverview` or `On this page` component overlapped content on small devices due to its inline style. 😥

![image](https://user-images.githubusercontent.com/48334856/194079728-614d0592-ed56-457b-901f-46db20a00a5d.png)

With that in mind, I created a separate file to handle its style and added a media query that changes its style to prevent the previous effect on devices with small screens. ✨

![image](https://user-images.githubusercontent.com/48334856/194079856-46baab01-5f25-42a2-a73b-e7d90999a9e6.png)