### PR TITLE
fix: CSS background specificity to respect the override order

### DIFF
--- a/src/styles/backgrounds.css
+++ b/src/styles/backgrounds.css
@@ -1,0 +1,69 @@
+
+@each $from, $to in (purple, yellow, cyan, pink), (cyan, pink, green, purple) {
+  .bg-$(from)-$(to) {
+    background: linear-gradient(
+      var(--gradientDegree),
+      var(--$(from)) 0%,
+      var(--$(to)) 100%
+    );
+  }
+
+  .bg-$(from)-$(to)-transparent {
+    background: linear-gradient(
+      var(--gradientDegree),
+      var(--$(from)-transparent) 0%,
+      var(--$(to)-transparent) 100%
+    );
+  }
+
+  .text-$(from)-$(to) {
+    background-image: linear-gradient(
+      var(--gradientDegree),
+      var(--$(from)) 0%,
+      var(--$(to)) 100%
+    );
+
+    background-size: 100%;
+    background-clip: text;
+
+    -webkit-background-clip: text;
+    -moz-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    -moz-text-fill-color: transparent;
+    -webkit-box-decoration-break: clone;
+  }
+}
+  
+@each $color in black, grey, white, cyan, green, orange, pink, purple, red, yellow {
+  .bg-$(color) {
+    background-color: var(--$(color));
+  }
+
+  .bg-$(color)-secondary {
+    --accentColor: var(--$(color)Secondary);
+    background-color: var(--$(color)Secondary);
+  }
+
+  .bg-$(color)-transparent {
+    --accentColor: var(--$(color)-transparent);
+    background-color: var(--$(color)-transparent);
+  }
+
+  .text-$(color) {
+    color: var(--$(color));
+  }
+
+  .text-$(color)-secondary {
+    color: var(--$(color)Secondary);
+  }
+
+  .glow-$(color) {
+    background-color: var(--$(color));
+    --glowColor: var(--$(color));
+  }
+
+  .border-$(color) {
+    border-color: var(--$(color));
+    --borderColor: var(--$(color));
+  }
+}

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -76,75 +76,6 @@
   }
 }
 
-@each $from, $to in (purple, yellow, cyan, pink), (cyan, pink, green, purple) {
-  .bg-$(from)-$(to) {
-    background: linear-gradient(
-      var(--gradientDegree),
-      var(--$(from)) 0%,
-      var(--$(to)) 100%
-    );
-  }
-
-  .bg-$(from)-$(to)-transparent {
-    background: linear-gradient(
-      var(--gradientDegree),
-      var(--$(from)-transparent) 0%,
-      var(--$(to)-transparent) 100%
-    );
-  }
-
-  .text-$(from)-$(to) {
-    background-image: linear-gradient(
-      var(--gradientDegree),
-      var(--$(from)) 0%,
-      var(--$(to)) 100%
-    );
-
-    background-size: 100%;
-    background-clip: text;
-
-    -webkit-background-clip: text;
-    -moz-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    -moz-text-fill-color: transparent;
-    -webkit-box-decoration-break: clone;
-  }
-}
-
-@each $color in black, grey, white, cyan, green, orange, pink, purple, red, yellow {
-  .bg-$(color) {
-    background-color: var(--$(color));
-  }
-
-  .bg-$(color)-secondary {
-    --accentColor: var(--$(color)Secondary);
-    background-color: var(--$(color)Secondary);
-  }
-
-  .bg-$(color)-transparent {
-    --accentColor: var(--$(color)-transparent);
-    background-color: var(--$(color)-transparent);
-  }
-
-  .text-$(color) {
-    color: var(--$(color));
-  }
-
-  .text-$(color)-secondary {
-    color: var(--$(color)Secondary);
-  }
-
-  .glow-$(color) {
-    background-color: var(--$(color));
-    --glowColor: var(--$(color));
-  }
-
-  .border-$(color) {
-    border-color: var(--$(color));
-    --borderColor: var(--$(color));
-  }
-}
-
 .bg-animated {
   content: '';
   animation: animatedGradient 6s ease infinite alternate;
@@ -172,3 +103,4 @@
     background-position: 0 50%;
   }
 }
+

--- a/src/styles/dracula-ui.css
+++ b/src/styles/dracula-ui.css
@@ -15,3 +15,4 @@
 @import './tabs.css';
 @import './table.css';
 @import './list.css';
+@import './backgrounds.css';


### PR DESCRIPTION
To fix the CSS background specificity, I split the colors CSS em two separate files, the first one with all the colors definition to keep it on top, and the second one is reserved for background definitions which can be used as an appearance modifier as well. This file should be placed below the CSS components files to respect the specificity override order.

After these changes we can use the background variants for the cards:
![image](https://user-images.githubusercontent.com/1820920/194490802-5010401b-a20f-4220-aff1-4b2cb4b0492b.png)

This PR closes #103 