### PR TITLE
add unpkg CDN option to README and html example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also import Dracula UI via npm's [unpkg CDN](https://unpkg.com):
 ```html
 <link
   rel="stylesheet"
-  href="href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"
+  href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can use Dracula UI with plain HTML by importing the CSS file.
 />
 ```
 
-You can also import Dracula UI via npm's unpkg CDN:
+You can also import Dracula UI via npm's [unpkg CDN](https://unpkg.com):
 
 ```html
 <link

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ You can use Dracula UI with plain HTML by importing the CSS file.
 />
 ```
 
+You can also import Dracula UI via npm's unpkg CDN:
+
+```html
+<link
+  rel="stylesheet"
+  href="href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"
+/>
+```
+
 Now you can take advantage of all the classes, for example:
 
 ```html

--- a/examples/with-html/index.html
+++ b/examples/with-html/index.html
@@ -13,7 +13,7 @@
       href="node_modules/dracula-ui/styles/dracula-ui.css"
     />
 
-    <!-- Optional - link with CDN: 
+    <!-- You can also import Dracula UI via npm's [unpkg CDN](https://unpkg.com):
       <link
         rel="stylesheet"
         href="href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"

--- a/examples/with-html/index.html
+++ b/examples/with-html/index.html
@@ -13,6 +13,14 @@
       href="node_modules/dracula-ui/styles/dracula-ui.css"
     />
 
+    <!-- Optional - link with CDN: 
+      <link
+        rel="stylesheet"
+        href="href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"
+      />
+    -->
+    
+
     <title>Dracula UI with HTML</title>
 
   </head>

--- a/examples/with-html/index.html
+++ b/examples/with-html/index.html
@@ -16,7 +16,7 @@
     <!-- You can also import Dracula UI via npm's [unpkg CDN](https://unpkg.com):
       <link
         rel="stylesheet"
-        href="href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"
+        href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css"
       />
     -->
     


### PR DESCRIPTION
I thought it might be useful to include the CDN link to the npm package as way to import Dracula UI