### PR TITLE
docs: add more installation instructions on website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ yarn add dracula-ui
 You can use Dracula UI with plain HTML by importing the CSS file.
 
 ```html
-<link
-  rel="stylesheet"
-  href="node_modules/dracula-ui/styles/dracula-ui.css"
-/>
+<link rel="stylesheet" href="node_modules/dracula-ui/styles/dracula-ui.css" />
+```
+
+Or by importing it on your main JavaScript file (when using a tool like [Vite](https://vitejs.dev/), for example).
+
+```js
+import 'dracula-ui/styles/dracula-ui.css'
 ```
 
 You can also import Dracula UI via npm's [unpkg CDN](https://unpkg.com):

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,9 @@
   "name": "website",
   "version": "1.0.0",
   "description": "Dracula UI site",
+  "engines": {
+    "node": ">=10 <17.0.0"
+  },
   "scripts": {
     "dev": "next dev"
   },

--- a/website/pages/installation.js
+++ b/website/pages/installation.js
@@ -43,6 +43,29 @@ yarn add dracula-ui`}
             code={`<link rel="stylesheet" href="node_modules/dracula-ui/styles/dracula-ui.css" />`}
           />
           <Paragraph>
+            Or by importing it on your main JavaScript file (when using a tool
+            like
+            <Anchor href="https://vitejs.dev/" isExternal={true} pl="xxs">
+              Vite
+            </Anchor>
+            , for example).
+          </Paragraph>
+          <CodeHighlight
+            language="js"
+            code={`import 'dracula-ui/styles/dracula-ui.css'`}
+          />
+          <Paragraph>
+            You can also import Dracula UI via npm's
+            <Anchor href="https://unpkg.com" isExternal={true} pl="xxs">
+              unpkg CDN
+            </Anchor>
+            :
+          </Paragraph>
+          <CodeHighlight
+            language="html"
+            code={`<link rel="stylesheet" href="https://unpkg.com/dracula-ui@1.0.3/styles/dracula-ui.css" />`}
+          />
+          <Paragraph>
             Now you can take advantage of all the classes, for example:
           </Paragraph>
           <CodeHighlight


### PR DESCRIPTION
This PR adds more instructions to install the package when using plain HTML or using a tool like Vite that can handle the CSS by importing it directly on the JavaScript.

The CDN installation text from #151 was added to website, since it is really helpful but was only available on the README.

Also, I set the required Node version on `package.json` as `>=10 <17.0.0`, since I was using v18.12.1 and some errors occurred when running the NextJS project, and by using v16.17.1 it runs with no errors