### PR TITLE
Fixes classname in colors documentation

### DIFF
--- a/website/pages/colors.js
+++ b/website/pages/colors.js
@@ -160,7 +160,7 @@ class Colors extends React.Component {
 
           <Box my="sm" color="blackSecondary" rounded="base">
             <Box color="blackSecondary" p="lg" my="xxs" rounded="base">
-              <Text color="blackLight">.drac-black-secondary</Text>
+              <Text color="blackLight">.drac-bg-black-secondary</Text>
             </Box>
           </Box>
 


### PR DESCRIPTION
The classname in the documentation [here](https://ui.draculatheme.com/colors) is `.drac-black-secondary` but the correct classname should be `.drac-bg-black-secondary`.

![Screenshot from 2023-06-15 20-25-05](https://github.com/dracula/dracula-ui/assets/77718741/bf27da1b-7a15-43e6-99e3-e2509ac49f85)
